### PR TITLE
Improve toolbar styling

### DIFF
--- a/olwebsite-app/src/components/Toolbar/Toolbar.jsx
+++ b/olwebsite-app/src/components/Toolbar/Toolbar.jsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { Link, withRouter } from "react-router-dom";
-import { NavLink } from "react-router-dom";
+import { Link, NavLink, withRouter } from "react-router-dom";
 
 import homeLogo from "../../images/homeLogo.png";
 
@@ -23,13 +22,13 @@ function Toolbar() {
             </h1>
           </li>
           <li>
-            <NavLink to="/about-us">About Us</NavLink>
+            <NavLink to="/about-us" activeClassName="active-link">About Us</NavLink>
           </li>
           <li>
-            <NavLink to="/posts">Posts</NavLink>
+            <NavLink to="/posts" activeClassName="active-link">Posts</NavLink>
           </li>
           <li>
-            <NavLink to="/partners">Partners</NavLink>
+            <NavLink to="/partners" activeClassName="active-link">Partners</NavLink>
           </li>
         </ul>
       </nav>
@@ -38,9 +37,9 @@ function Toolbar() {
           <FaSearch tabIndex="0" />
         </li>
         <li>
-          <Link to="/login">
+          <NavLink to="/login" activeClassName="active-link">
             <FaUser />
-          </Link>
+          </NavLink>
         </li>
       </ul>
     </header>

--- a/olwebsite-app/src/style-sheets/layout/_app.scss
+++ b/olwebsite-app/src/style-sheets/layout/_app.scss
@@ -1,4 +1,3 @@
-
 .app {
   width: 101%;
   
@@ -10,10 +9,15 @@
       }
 }
 
-@media only screen and (max-width: 635px) {
-  /* For Mobile: */
+@media only screen and (max-width: 1100px) {
   .app-body {
-    width: 101%;
+      padding-top: 9%;
   }
 }
 
+@media only screen and (max-width: 635px) {
+  .app-body {
+    width: 101%;
+    padding-top: 3%;
+  }
+}

--- a/olwebsite-app/src/style-sheets/layout/_hamburger-toolbar.scss
+++ b/olwebsite-app/src/style-sheets/layout/_hamburger-toolbar.scss
@@ -2,6 +2,7 @@
     width: 101%;
     background-color: #ffffff;
     color: black;
+    border-bottom: 2pt solid #296C37;
 
     & nav {
         overflow: hidden;
@@ -49,6 +50,10 @@
 
         & li {
             list-style: none;
+            
+            & svg {
+                color: #296C37;
+            }
 
             & a {
                 color: white;

--- a/olwebsite-app/src/style-sheets/layout/_toolbar.scss
+++ b/olwebsite-app/src/style-sheets/layout/_toolbar.scss
@@ -1,5 +1,6 @@
 #toolBar {
     background-color: #ffffff;
+    border-bottom: 2pt solid #296C37;
     color: black;
     height: 50px;
 
@@ -28,7 +29,7 @@
     & ul.icon-module li {
         & svg {
             cursor: pointer;
-            color: #000000;
+            color: #296C37;
 
             &:hover {
                 opacity: 0.7;
@@ -94,4 +95,9 @@
             }
         }
     }
+
+    .active-link {
+        font-weight: bold;
+    }
 }
+


### PR DESCRIPTION
Updated Toolbar styling to look like mock ups, could not get the black border under link when active since that would be on the link and the border for the toolbar is connected to header. Will still show selected link in bold to show where user is