### PR TITLE
Bugfix/On link change make view scroll to top

### DIFF
--- a/olwebsite-app/src/OlWebsiteApp.jsx
+++ b/olwebsite-app/src/OlWebsiteApp.jsx
@@ -10,6 +10,7 @@ import LandingView from "./pages/LandingView";
 import PostsView from "./pages/PostsView";
 import RegisterView from "./pages/RegisterView";
 import LoginView from "./pages/LoginView";
+import ScrollToTop from "./components/ScrollToTop";
 
 export default function OlWebsiteApp() {
   /************************************
@@ -20,14 +21,16 @@ export default function OlWebsiteApp() {
     <div className="app">
       <Router basename={process.env.PUBLIC_URL}>
         <ToolbarContainer />
-        <div className="app-body">
-          <Switch>
-            <Route path="/login" component={LoginView} />
-            <Route path="/posts" component={PostsView} />
-            <Route path="/sign-up" component={RegisterView} />
-            <Route path="/" component={LandingView} />
-          </Switch>
-        </div>
+        <ScrollToTop>
+          <div className="app-body">
+            <Switch>
+              <Route path="/login" component={LoginView} />
+              <Route path="/posts" component={PostsView} />
+              <Route path="/sign-up" component={RegisterView} />
+              <Route path="/" component={LandingView} />
+            </Switch>
+          </div>
+        </ScrollToTop>
         <Footer />
       </Router>
     </div>

--- a/olwebsite-app/src/components/ScrollToTop.jsx
+++ b/olwebsite-app/src/components/ScrollToTop.jsx
@@ -1,0 +1,25 @@
+import React, { useEffect } from 'react';
+import { withRouter } from 'react-router-dom';
+
+function ScrollToTop({ history, children }) {
+  /************************************
+   * Life Cycle Hooks
+   ************************************/
+
+  useEffect(() => {
+    const unlisten = history.listen(() => {
+      window.scrollTo(0, 0);
+    });
+    return () => {
+      unlisten();
+    }
+  }, [history]);
+
+  /************************************
+   * Render
+   ************************************/
+
+  return <>{children}</>;
+}
+
+export default withRouter(ScrollToTop);


### PR DESCRIPTION
When a link was clicked and the view was at any part of the change, then the next view would appear at the same scroll level. This fix makes sure the view is at the top of the page whenever the route is changed