### PR TITLE
Deploy dev page to dev.oneleif.com

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,9 +98,20 @@ workflows:
           filters:
             branches:
               only:
-                - develop
+                - develop-v1
                 - master
-      - deploy_production:
+      - deploy:
+          name: deploy_develop_v1
+          bucket_url: S3_BUCKET_URL_DEV
+          context: oneleif-aws
+          requires:
+            - build
+          filters:
+            branches:
+              only: develop-v1
+      - deploy:
+          name: deploy_propuction
+          bucket_url: S3_BUCKET_URL_PROD
           context: oneleif-aws
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,14 +69,17 @@ jobs:
           paths:
             - ./build
 
-  deploy_production:
+  deploy:
     <<: *defaults
+    parameters:
+      bucket_url:
+        type: env_var_name
     steps:
       - attach_workspace:
           at: ~/repo
       - aws-s3/sync:
           from: ./build
-          to: $S3_BUCKET_URL_PROD
+          to: ${<< parameters.bucket_url >>}
           overwrite: true
           arguments: |
             --acl public-read \


### PR DESCRIPTION
This will deploy the code from `develop` branch into `dev.oneleif.com` website.

Still wasn't sure which branch should go where, but this is easy to change.

Note: the `dev.oneleif.com` website might forward directly to S3 website as the DNS changes must go live (it takes a bit).

Closes #111 