### PR TITLE
[#138] Toolbar covering headers in mobile view

### DIFF
--- a/src/style-sheets/components/_page-header.scss
+++ b/src/style-sheets/components/_page-header.scss
@@ -1,6 +1,5 @@
 .page-header-container {
     width: 81.5%;
-    margin-top: 5%;
     display: flex;
     flex-direction: column;
     font-family: $olBaseFont;
@@ -52,7 +51,6 @@
     
 @include medium('up') {
     .page-header-container {
-        margin-top: 0;
         display: grid;
         grid-template-columns: 2fr 1fr 1fr 2fr;
         grid-template-rows: auto;

--- a/src/style-sheets/components/_toolbar.scss
+++ b/src/style-sheets/components/_toolbar.scss
@@ -1,5 +1,6 @@
 .navbar {
   width: 100%;
+  height: 100px;
   padding: 0 5%;
   background-color: $white;
 
@@ -71,6 +72,7 @@
   }
 
   @include medium('down') {
+    height: 63px;
     padding: 0;
 
     & ul {

--- a/src/style-sheets/layout/_app.scss
+++ b/src/style-sheets/layout/_app.scss
@@ -2,25 +2,17 @@
   width: 100%;
   
     &-body {
-        max-width: 1440px;
-        margin: 0 auto;
-  
-        background-color: $olLTPrimary;
-        display: flex;
-        flex-direction: column;
-        padding-top: 5%;
+      max-width: 1440px;
+      margin: 0 auto;
+
+      background-color: $olLTPrimary;
+      display: flex;
+      flex-direction: column;
+      padding-top: 100px;
+
+      @include medium('down') {
+        padding-top: 63px;
       }
-}
-
-@media only screen and (max-width: 1100px) {
-  .app-body {
-      padding-top: 9%;
-  }
-}
-
-@media only screen and (max-width: 635px) {
-  .app-body {
-    width: 100%;
-    padding-top: 3%;
-  }
+        
+    }
 }

--- a/src/style-sheets/pages/_contact-us-view.scss
+++ b/src/style-sheets/pages/_contact-us-view.scss
@@ -12,7 +12,6 @@
         justify-content: space-between;
 
         & .contact-us-copy-container {
-            margin: 8% 0;
             width: 45%;
             display: flex;
             flex-direction: column;
@@ -45,7 +44,6 @@
         }
 
         & .contact-us-form-container {
-            margin: 8% 0;
             padding-top: 2%;
             width: 50%;
             display: flex;

--- a/src/style-sheets/pages/_meet-the-team-view.scss
+++ b/src/style-sheets/pages/_meet-the-team-view.scss
@@ -2,6 +2,5 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    margin: 8% 0;
 }
 

--- a/src/style-sheets/pages/_projects-view.scss
+++ b/src/style-sheets/pages/_projects-view.scss
@@ -19,7 +19,6 @@
         }
 
         & .projects-view-copy-container {
-            margin: 8% 0;
             display: flex;
             flex-direction: column;
 
@@ -59,7 +58,6 @@
 @include small('down') {
     .projects-view-container {
         & .projects-view-body {
-            margin: 8% 0;
             flex-direction: column;
             align-items: center;
 


### PR DESCRIPTION
Issue reference: https://github.com/oneleif/olWebsite-React/issues/138

This PR:
- Adds a fixed height to `navbar` (63px for mobile and 100px for desktop)
- Adds a fixed padding to `app-body` div (same value as `navbar` height)

How it should look after this PR:
![Screen Shot 2020-05-07 at 23 08 47](https://user-images.githubusercontent.com/8450941/81362782-088c0e00-90b8-11ea-8371-9e9d72c16b1c.png)
![Screen Shot 2020-05-07 at 23 10 50](https://user-images.githubusercontent.com/8450941/81362784-0b86fe80-90b8-11ea-8466-167bef43c5db.png)
