### PR TITLE
project copy now reflects active projects

### DIFF
--- a/src/components/Footer/js/footerLinks.js
+++ b/src/components/Footer/js/footerLinks.js
@@ -1,45 +1,6 @@
 import projectCards from '../../../pages/js/projects.js';
 
-//  static data can be generated from the projects.js file
-// [
-//   {
-//     label: 'Oneleif',
-//     path: '/projects',
-//     internal: true
-//   },
-//   {
-//     label: 'Bread for the Journey',
-//     path: '/projects',
-//     internal: true
-//   },
-//   {
-//     label: 'Swift UI Kit',
-//     path: '/projects',
-//     internal: true
-//   },
-//   {
-//     label: 'Leifdown',
-//     path: '/projects',
-//     internal: true
-//   },
-//   {
-//     label: 'Filodex',
-//     path: '/projects',
-//     internal: true
-//   },
-//   {
-//     label: 'Onefit',
-//     path: '/projects',
-//     internal: true
-//   }
-// ]
-
-/************************************
- * Proposal
- ************************************/
-// the data can be generated creating the array of objects
-// pros: less code
-// cons: logic implementation if path and internal differ between objects
+// TODO: load links from API
 
 const parseLinks = projectCards.map(project => {
   return {

--- a/src/components/Footer/js/footerLinks.js
+++ b/src/components/Footer/js/footerLinks.js
@@ -1,6 +1,62 @@
+import projectCards from '../../../pages/js/projects.js';
+
+//  static data can be generated from the projects.js file
+// [
+//   {
+//     label: 'Oneleif',
+//     path: '/projects',
+//     internal: true
+//   },
+//   {
+//     label: 'Bread for the Journey',
+//     path: '/projects',
+//     internal: true
+//   },
+//   {
+//     label: 'Swift UI Kit',
+//     path: '/projects',
+//     internal: true
+//   },
+//   {
+//     label: 'Leifdown',
+//     path: '/projects',
+//     internal: true
+//   },
+//   {
+//     label: 'Filodex',
+//     path: '/projects',
+//     internal: true
+//   },
+//   {
+//     label: 'Onefit',
+//     path: '/projects',
+//     internal: true
+//   }
+// ]
+
+/************************************
+ * Proposal
+ ************************************/
+// the data can be generated creating the array of objects
+// pros: less code
+// cons: logic implementation if path and internal differ between objects
+
+const parseLinks = projectCards.map(project => {
+  return {
+    label: project.name,
+    path: '/projects',
+    internal: true
+  };
+});
+
+/************************************
+ *
+ ************************************/
+
 const footerLinks = [
   {
-    header: 'Projects'
+    header: 'Projects',
+    links: parseLinks
   },
   {
     header: 'Resources',

--- a/src/pages/js/projects.js
+++ b/src/pages/js/projects.js
@@ -1,54 +1,48 @@
 const projectCards = [
   {
     img: '',
-    name: 'Swift UI Kit',
-    type: 'Community Project',
-    details: 'Lorem ipsum dolor sit amet, consectetur and more stuff here and here and here.',
-    tags: ['Development', 'Website', 'Development', '+2']
+    name: 'Oneleif Website',
+    type: 'Organization Project',
+    details: 'Grow and create together.',
+    tags: ['Development', 'Community', 'Experience']
+  },
+
+  {
+    img: '',
+    name: 'Bread for the Journey',
+    type: 'Organization Project',
+    details: 'BFJ helps make passion projects come to life that are intended to enrich the community.',
+    tags: ['Non-profit', 'Grants', 'Omaha']
   },
 
   {
     img: '',
     name: 'Swift UI Kit',
     type: 'Community Project',
-    details: 'Lorem ipsum dolor sit amet, consectetur and more stuff here and here and here.',
-    tags: ['Development', 'Website', 'Development', '+2']
-  },
-
-  {
-    img: '',
-    name: 'Swift UI Kit',
-    type: 'Community Project',
-    details: 'Lorem ipsum dolor sit amet, consectetur and more stuff here and here and here.',
-    tags: ['Development', 'Website', 'Development', '+2']
+    details: 'UIKit code that is fun to write.',
+    tags: ['Swift', 'UI', 'Framework']
   },
   {
     img: '',
-    name: 'Swift UI Kit',
+    name: 'Leifdown',
     type: 'Community Project',
-    details: 'Lorem ipsum dolor sit amet, consectetur and more stuff here and here and here.',
-    tags: ['Development', 'Website', 'Development', '+2']
+    details: 'Markdown Conversion Tool.',
+    tags: ['Markdown', 'JSX', 'Converter']
   },
   {
     img: '',
-    name: 'Swift UI Kit',
+    name: 'Filodex',
     type: 'Community Project',
-    details: 'Lorem ipsum dolor sit amet, consectetur and more stuff here and here and here.',
-    tags: ['Development', 'Website', 'Development', '+2']
+    details:
+      'Centralized repository of knowledge, tools, funding opportunities, and other resources for individuals in the non-profit sector.',
+    tags: ['Community', 'Non-profit', 'Resources']
   },
   {
     img: '',
-    name: 'Swift UI Kit',
+    name: 'Onefit',
     type: 'Community Project',
-    details: 'Lorem ipsum dolor sit amet, consectetur and more stuff here and here and here.',
-    tags: ['Development', 'Website', 'Development', '+2']
-  },
-  {
-    img: '',
-    name: 'Swift UI Kit',
-    type: 'Community Project',
-    details: 'Lorem ipsum dolor sit amet, consectetur and more stuff here and here and here.',
-    tags: ['Development', 'Website', 'Development', '+2']
+    details: 'Fitness Tracker/Logger/Planner.',
+    tags: ['Community', 'Fitness', 'Planner']
   }
 ];
 

--- a/src/style-sheets/components/_meet-the-team-card.scss
+++ b/src/style-sheets/components/_meet-the-team-card.scss
@@ -3,7 +3,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  
+
   width: 323px;
   height: 200px;
   padding: 5% 0;
@@ -20,22 +20,22 @@
   .card {
     &-content {
       display: grid;
-      grid-template-columns: 1fr .4fr 4fr;
-      grid-template-rows: .2fr .2fr .2fr;
+      grid-template-columns: 1fr 0.4fr 4fr;
+      grid-template-rows: 0.2fr 0.2fr 0.2fr;
       grid-template-areas:
-          "img . fullname"
-          "img . member-role"
-          "img . location";
+        'img . fullname'
+        'img . member-role'
+        'img . location';
 
       width: 90%;
       margin-bottom: 1.7143em;
 
-      @include query($screen-sm, $screen-md) { 
+      @include query($screen-sm, $screen-md) {
         width: 87%;
       }
 
       @include medium('up') {
-        grid-template-columns: 1fr .5fr 4fr;
+        grid-template-columns: 1fr 0.5fr 4fr;
         margin-bottom: 2.14285em;
       }
 
@@ -52,8 +52,9 @@
         margin-block-start: 1em;
         margin-block-end: 0;
         line-height: 24px;
+        text-align: center;
 
-        @include query($screen-sm, $screen-md) { 
+        @include query($screen-sm, $screen-md) {
           font-size: 1.2rem;
         }
       }
@@ -67,8 +68,8 @@
         line-height: 22px;
 
         @include large('up') {
-          font-size: .85rem;
-        }      
+          font-size: 0.85rem;
+        }
       }
 
       .role-copy {
@@ -92,6 +93,5 @@
         margin-bottom: 0;
       }
     }
-
   }
 }

--- a/src/style-sheets/components/_project-card.scss
+++ b/src/style-sheets/components/_project-card.scss
@@ -20,9 +20,9 @@
       grid-template-columns: 84px 1fr 4fr;
       grid-template-rows: auto;
       grid-template-areas:
-          "img name name"
-          "img type type"
-          "details details details";
+        'img name name'
+        'img type type'
+        'details details details';
 
       width: 90%;
       margin-bottom: 1em;
@@ -34,7 +34,6 @@
         align-items: center;
       }
 
-      
       img {
         grid-area: img;
         width: 54px;
@@ -56,10 +55,11 @@
         line-height: 32px;
         align-self: flex-end;
         color: $black;
+        text-align: center;
 
         @include medium('up') {
           align-self: center;
-          font-size:  1.875rem;
+          font-size: 1.875rem;
           margin-bottom: 0.25em;
         }
       }


### PR DESCRIPTION
# summary

## result

the proper files have been updated with the active projects, the path `/projects` now renders the new data: 

<img width="826" alt="Screen Shot 2021-01-22 at 8 17 11 PM" src="https://user-images.githubusercontent.com/55143159/105564131-d1659780-5cee-11eb-874f-bd06dc26c5d7.png">

## concerns

* there were no images provided for each individual project, the default image (**A**) is been used as a placeholder.
* project name (**B**) is align to the left if there's a line break.
* the project description (**C**) was taken from repos and websites.

<img width="247" alt="Screen Shot 2021-01-22 at 8 18 40 PM" src="https://user-images.githubusercontent.com/55143159/105564328-b34c6700-5cef-11eb-8040-f060c7e893e0.png">

Fixes #250 

