### PR TITLE
Aligned profile heading with rest of copy

### DIFF
--- a/src/style-sheets/components/_meet-the-team-card.scss
+++ b/src/style-sheets/components/_meet-the-team-card.scss
@@ -52,7 +52,6 @@
         margin-block-start: 1em;
         margin-block-end: 0;
         line-height: 24px;
-        text-align: center;
 
         @include query($screen-sm, $screen-md) {
           font-size: 1.2rem;


### PR DESCRIPTION
Updated incorrect text-align in SCSS to correctly align heading with the rest of the profile card text.